### PR TITLE
Update GNOME runtime to 3.36

### DIFF
--- a/uk.co.ibboard.cawbird.json
+++ b/uk.co.ibboard.cawbird.json
@@ -1,7 +1,7 @@
 {
   "app-id":"uk.co.ibboard.cawbird",
   "runtime":"org.gnome.Platform",
-  "runtime-version":"3.34",
+  "runtime-version":"3.36",
   "sdk":"org.gnome.Sdk",
   "command":"cawbird",
   "finish-args":[


### PR DESCRIPTION
This could save a lot of disk space since almost all GTK/GNOME apps already switched to latest runtime.