### PR TITLE
Update to newest Gnome Runtime

### DIFF
--- a/uk.co.ibboard.cawbird.json
+++ b/uk.co.ibboard.cawbird.json
@@ -1,7 +1,7 @@
 {
     "app-id": "uk.co.ibboard.cawbird",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "cawbird",
     "finish-args": [


### PR DESCRIPTION
This updates the Flatpak to use the newest Gnome Runtime (41), which seems to fix [Issue 403](https://github.com/IBBoard/cawbird/issues/403) on the main repository.